### PR TITLE
Updated CMake to search for BLAS library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,16 @@
 # Check cmake version.
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.5)
 
 
 # Project specification.
-project (GSKNN)
+project (GSKNN C CXX)
 set (GSKNN_VERSION_MAJOR 1)
 set (GSKNN_VERSION_MINOR 1)
 set (GSKNN_VERSION_PATCH 0)
 set (GSKNN_VERSION ${GSKNN_VERSION_MAJOR}.${GSKNN_VERSION_MINOR}.${GSKNN_VERSION_PATCH})
 
+
+find_package(BLAS)
 
 # Configure the path structure.
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -17,6 +19,15 @@ set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set (CMAKE_RELEASE_POSTFIX "")
 set (CMAKE_DEBUG_POSTFIX "-debug")
 
+#set(SUPPORTED_PLATFORM true)
+#if(not CMAKE_SYSTEM_PROCESSOR)
+#  message(WARNING "Target processor architecture is not specified.")
+#  set(SUPPORTED_PLATFORM false)
+#elseif(not CMAKE_SYSTEM_PROCESSOR matches "^(AMD64|x86_64|armv7|armv7f|armv7s|armv7k|arm64|aarch64)$")
+#  message(WARNING "Target processor architecture ${CMAKE_SYSTEM_PROCESSOR} is not supported in GSKNN.")
+#  set(SUPPORTED_PLATFORM false)
+#endif()
+  
 
 # Turn on testing.
 ENABLE_TESTING()
@@ -27,45 +38,36 @@ set (GSKNN_ARCH_MAJOR $ENV{GSKNN_ARCH_MAJOR})
 set (GSKNN_ARCH_MINOR $ENV{GSKNN_ARCH_MINOR})
 set (GSKNN_ARCH ${GSKNN_ARCH_MAJOR}/${GSKNN_ARCH_MINOR})
 
-
+message("Compiler ID: ${CMAKE_C_COMPILER_ID}")
 # Compiler Options.
-if ($ENV{GSKNN_USE_INTEL} MATCHES "true")
-  set (CMAKE_C_COMPILER   icc )
-  set (CMAKE_CXX_COMPILER icpc)
-  #set (GSKNN_CFLAGS          "-O2 -openmp -mfloat-abi=hard -mfpu=neon -march=armv7-a")
-  set (GSKNN_CFLAGS          "-O2 -openmp -mavx")
-  set (CMAKE_EXE_LINKER_FLAGS "-lpthread -openmp -lm")
-else ($ENV{GSKNN_USE_INTEL} MATCHES "true")
-  set (CMAKE_C_COMPILER   gcc)
-  set (CMAKE_CXX_COMPILER g++)
+if (${CMAKE_C_COMPILER_ID} MATCHES "Intel")
+  #set (CMAKE_C_COMPILER   icc )
+  #set (CMAKE_CXX_COMPILER icpc)
+  #set (GSKNN_CFLAGS          "-O2 -qopenmp -mfloat-abi=hard -mfpu=neon -march=armv7-a")
+  set (GSKNN_CFLAGS          "-O2 -qopenmp -mavx")
+  set (CMAKE_EXE_LINKER_FLAGS "-lpthread -qopenmp")
+else (${CMAKE_C_COMPILER_ID} MATCHES "GNU")
+  #set (CMAKE_C_COMPILER   gcc)
+  #set (CMAKE_CXX_COMPILER g++)
   #set (GSKNN_CFLAGS          "-O2 -fopenmp -mfloat-abi=hard -mfpu=neon -march=armv7-a")
   set (GSKNN_CFLAGS          "-O2 -fopenmp -mavx")
-  set (CMAKE_EXE_LINKER_FLAGS "-lpthread -fopenmp -lm")
-endif ($ENV{GSKNN_USE_INTEL} MATCHES "true")
+  set (CMAKE_EXE_LINKER_FLAGS "-lpthread -fopenmp")
+endif ()
 
-if ($ENV{GSKNN_USE_BLAS} MATCHES "true")
+find_package(BLAS)
+
+if (BLAS_FOUND)
+  link_libraries(${BLAS_LIBRARIES})
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${BLAS_LINKER_FLAGS}")
   set (GSKNN_CFLAGS          "${GSKNN_CFLAGS} -DUSE_BLAS")
-endif ($ENV{GSKNN_USE_BLAS} MATCHES "true")
+endif()
+
 set (CMAKE_C_FLAGS      "${CMAKE_C_FLAGS} ${GSKNN_CFLAGS}")
 set (CMAKE_CXX_FLAGS    "${CMAKE_CXX_FLAGS} ${GSKNN_CFLAGS}")
 
 
 # Software dependencies.
-set (MKL_DIR $ENV{GSKNN_MKL_DIR})
-
-
-# Linking infos.
-if ($ENV{GSKNN_USE_INTEL} MATCHES "true" AND $ENV{GSKNN_USE_BLAS} MATCHES "true")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mkl=parallel")
-endif ($ENV{GSKNN_USE_INTEL} MATCHES "true" AND $ENV{GSKNN_USE_BLAS} MATCHES "true")
-
-if ($ENV{GSKNN_USE_GNU} MATCHES "true" AND $ENV{GSKNN_USE_BLAS} MATCHES "true")
-    #set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /home/ubuntu/Work/Github/OpenBLAS/libopenblas.a")
-    link_directories(/home/ubuntu/Work/Github/OpenBLAS)
-endif ($ENV{GSKNN_USE_GNU} MATCHES "true" AND $ENV{GSKNN_USE_BLAS} MATCHES "true")
-  
-
-
+#set (MKL_DIR $ENV{GSKNN_MKL_DIR})
 
 # Headers.
 include_directories ("include" "${CMAKE_SOURCE_DIR}/kernels/${GSKNN_ARCH}" "${MKL_DIR}/include")
@@ -82,19 +84,18 @@ file (GLOB KERNEL_SRC ${CMAKE_SOURCE_DIR}/kernels/${GSKNN_ARCH}/*.c)
 # Build the static library.
 add_library (gsknn ${FRAME_CC_SRC} ${FRAME_CXX_SRC} ${KERNEL_SRC})
 
-
 # Build the executable files.
 add_executable (test_sgsknn.x ${CMAKE_SOURCE_DIR}/test/test_sgsknn.c)
-target_link_libraries(test_sgsknn.x gsknn)
+target_link_libraries(test_sgsknn.x gsknn m)
 #target_link_libraries(test_sgsknn.x openblas)
 add_executable (test_sgsknn_stl.x ${CMAKE_SOURCE_DIR}/test/test_sgsknn_stl.cpp)
-target_link_libraries(test_sgsknn_stl.x gsknn)
+target_link_libraries(test_sgsknn_stl.x gsknn m)
 #target_link_libraries(test_sgsknn_stl.x openblas)
 add_executable (test_dgsknn.x ${CMAKE_SOURCE_DIR}/test/test_dgsknn.c)
-target_link_libraries(test_dgsknn.x gsknn)
+target_link_libraries(test_dgsknn.x gsknn m)
 #target_link_libraries(test_dgsknn.x openblas)
 add_executable (test_dgsknn_stl.x ${CMAKE_SOURCE_DIR}/test/test_dgsknn_stl.cpp)
-target_link_libraries(test_dgsknn_stl.x gsknn)
+target_link_libraries(test_dgsknn_stl.x gsknn m)
 #target_link_libraries(test_dgsknn_stl.x openblas)
 
 
@@ -114,5 +115,5 @@ message ("CFLAGS       =${CMAKE_C_FLAGS}")
 message ("CXX          =${CMAKE_CXX_COMPILER}")
 message ("CXXFLAGS     =${CMAKE_CXX_FLAGS}")
 message ("Linker       =${CMAKE_EXE_LINKER_FLAGS}")
-message ("MKLDIR       =${MKL_DIR}")
+message ("MKLDIR       =${BLAS_LIBRARIES}")
 message ("===================================================")

--- a/set_env.sh
+++ b/set_env.sh
@@ -11,6 +11,7 @@ export GSKNN_ARCH_MINOR=sandybridge
 
 #export GSKNN_ARCH_MAJOR=arm
 #export GSKNN_ARCH_MINOR=neon
+
 export GSKNN_ARCH=$GSKNN_ARCH_MAJOR/$GSKNN_ARCH_MINOR
 echo "GSKNN_ARCH = $GSKNN_ARCH"
 
@@ -19,23 +20,17 @@ export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/intel/lib:/opt/intel/mkl/lib
 echo "DYLD_LIBRARY_PATH = $DYLD_LIBRARY_PATH"
 
 ## Compiler options (if false, then use GNU compilers)
-export GSKNN_USE_INTEL=true
-echo "GSKNN_USE_INTEL = $GSKNN_USE_INTEL"
-export GSKNN_USE_GNU=false
-echo "GSKNN_USE_GNU = $GSKNN_USE_GNU"
+#export GSKNN_USE_INTEL=true
+#echo "GSKNN_USE_INTEL = $GSKNN_USE_INTEL"
+#export GSKNN_USE_GNU=false
+#echo "GSKNN_USE_GNU = $GSKNN_USE_GNU"
 
 ## Whether use BLAS or not?
-export GSKNN_USE_BLAS=false
+export GSKNN_USE_BLAS="True"
 echo "GSKNN_USE_BLAS = $GSKNN_USE_BLAS"
 
-## Manually set the mkl or openblas path
-export GSKNN_MKL_DIR=/opt/intel/mkl
-#export GSKNN_MKL_DIR=$TACC_MKL_DIR
-echo "GSKNN_MKL_DIR = $GSKNN_MKL_DIR"
-
-export GSKNN_OPENBLAS_DIR=
-echo "GSKNN_OPENBLAS_DIR = $GSKNN_OPENBLAS_DIR"
-
+## Manually set the mkl path/hint
+export MKLROOT=""
 
 ## Parallel options
 export KMP_AFFINITY=compact


### PR DESCRIPTION
Hi Chenhan, 

We're planning on using GSKNN as a submodule in the distributed PYRKNN code. 
While I was cleaning up the build system for that I updated the GSKNN CMake to automatically search for the compiler and BLAS version. 

Its a simple change, I didn't touch the standard makefiles and the user would still have to specify the paths for the Matlab interface. 